### PR TITLE
fix: SocialLoginService 분리하고 MockLoginService 구현 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+src/main/resources/application-local.yml
+src/main/resources/application.yml

--- a/src/main/java/com/jangburich/domain/user/controller/UserController.java
+++ b/src/main/java/com/jangburich/domain/user/controller/UserController.java
@@ -1,10 +1,13 @@
 package com.jangburich.domain.user.controller;
 
 import com.jangburich.domain.user.domain.AdditionalInfoCreateDTO;
+import com.jangburich.domain.user.domain.SocialLoginProvider;
 import com.jangburich.domain.user.domain.TokenResponseDTO;
 import com.jangburich.domain.user.domain.User;
 import com.jangburich.domain.user.dto.response.UserHomeResponse;
 import com.jangburich.domain.user.dto.response.WalletResponse;
+import com.jangburich.domain.user.service.SocialLoginService;
+import com.jangburich.domain.user.service.SocialLoginServiceFactory;
 import com.jangburich.domain.user.service.UserService;
 import com.jangburich.global.payload.Message;
 import com.jangburich.global.payload.ResponseCustom;
@@ -26,10 +29,14 @@ import java.util.Map;
 public class UserController {
 
 	private final UserService userService;
+	private final SocialLoginServiceFactory socialLoginServiceFactory;
 
 	@PostMapping("/login")
-	public ResponseCustom<TokenResponseDTO> login(@RequestParam String authorizationHeader) {
-		TokenResponseDTO login = userService.login(authorizationHeader);
+	public ResponseCustom<TokenResponseDTO> login(
+			@RequestParam SocialLoginProvider provider,
+			@RequestParam String authorizationHeader) {
+		SocialLoginService service = socialLoginServiceFactory.getService(provider);
+		TokenResponseDTO login = service.login(authorizationHeader);
 		return ResponseCustom.OK(login);
 	}
 
@@ -40,13 +47,19 @@ public class UserController {
 	}
 
 	@PostMapping("/join/user")
-	public ResponseCustom<TokenResponseDTO> joinUser(@RequestParam String authorizationHeader) {
-		return ResponseCustom.OK(userService.joinUser(authorizationHeader));
+	public ResponseCustom<TokenResponseDTO> joinUser(
+			@RequestParam SocialLoginProvider provider,
+			@RequestParam String authorizationHeader) {
+		SocialLoginService service = socialLoginServiceFactory.getService(provider);
+		return ResponseCustom.OK(service.joinUser(authorizationHeader));
 	}
 
 	@PostMapping("/join/owner")
-	public ResponseCustom<TokenResponseDTO> joinOwner(@RequestParam String authorizationHeader) {
-		return ResponseCustom.OK(userService.joinOwner(authorizationHeader));
+	public ResponseCustom<TokenResponseDTO> joinOwner(
+			@RequestParam SocialLoginProvider provider,
+			@RequestParam String authorizationHeader) {
+		SocialLoginService service = socialLoginServiceFactory.getService(provider);
+		return ResponseCustom.OK(service.joinOwner(authorizationHeader));
 	}
 
 	@PostMapping("/token/reissue")

--- a/src/main/java/com/jangburich/domain/user/domain/SocialLoginProvider.java
+++ b/src/main/java/com/jangburich/domain/user/domain/SocialLoginProvider.java
@@ -1,0 +1,8 @@
+package com.jangburich.domain.user.domain;
+
+public enum SocialLoginProvider {
+    KAKAO
+    , GOOGLE
+    , APPLE
+    ,LOCAL
+}

--- a/src/main/java/com/jangburich/domain/user/domain/SocialUserProfileDTO.java
+++ b/src/main/java/com/jangburich/domain/user/domain/SocialUserProfileDTO.java
@@ -1,0 +1,24 @@
+package com.jangburich.domain.user.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class SocialUserProfileDTO {
+    @JsonProperty("social_id")
+    private String socialId;
+
+    @JsonProperty("email")
+    private String email;
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("profile_image")
+    private String profileImage;
+
+    @JsonProperty("provider")
+    private SocialLoginProvider provider;
+}

--- a/src/main/java/com/jangburich/domain/user/service/SocialLoginService.java
+++ b/src/main/java/com/jangburich/domain/user/service/SocialLoginService.java
@@ -1,0 +1,13 @@
+package com.jangburich.domain.user.service;
+
+import com.jangburich.domain.user.domain.SocialLoginProvider;
+import com.jangburich.domain.user.domain.SocialUserProfileDTO;
+import com.jangburich.domain.user.domain.TokenResponseDTO;
+
+public interface SocialLoginService {
+    SocialLoginProvider getProvider();
+    SocialUserProfileDTO getUserInfo(String accessToken);
+    TokenResponseDTO login(String accessToken);
+    TokenResponseDTO joinUser(String accessToken);
+    TokenResponseDTO joinOwner(String accessToken);
+}

--- a/src/main/java/com/jangburich/domain/user/service/SocialLoginServiceFactory.java
+++ b/src/main/java/com/jangburich/domain/user/service/SocialLoginServiceFactory.java
@@ -1,0 +1,25 @@
+package com.jangburich.domain.user.service;
+
+import com.jangburich.domain.user.domain.SocialLoginProvider;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+public class SocialLoginServiceFactory {
+    private final Map<SocialLoginProvider, SocialLoginService> serviceMap;
+
+    public SocialLoginServiceFactory(List<SocialLoginService> services) {
+        this.serviceMap = services.stream()
+                .collect(Collectors.toMap(SocialLoginService::getProvider, Function.identity()));
+    }
+
+    public SocialLoginService getService(SocialLoginProvider provider){
+        return Optional.ofNullable(serviceMap.get(provider))
+                .orElseThrow(()->new IllegalArgumentException("지원하지 않는 소셜 로그인입니다: "+provider));
+    }
+}

--- a/src/main/java/com/jangburich/domain/user/service/UserService.java
+++ b/src/main/java/com/jangburich/domain/user/service/UserService.java
@@ -4,25 +4,13 @@ import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
 
-import com.jangburich.domain.owner.domain.Owner;
-import com.jangburich.domain.owner.domain.repository.OwnerRepository;
 import com.jangburich.domain.point.domain.PointTransaction;
 import com.jangburich.domain.point.domain.TransactionType;
 import com.jangburich.domain.point.domain.repository.PointTransactionRepository;
-import com.jangburich.domain.store.domain.Store;
-import com.jangburich.domain.store.repository.StoreRepository;
 import com.jangburich.domain.user.domain.AdditionalInfoCreateDTO;
-import com.jangburich.domain.user.domain.KakaoApiResponseDTO;
-import com.jangburich.domain.user.domain.TokenResponseDTO;
 import com.jangburich.domain.user.domain.User;
 import com.jangburich.domain.user.dto.response.PurchaseHistory;
 import com.jangburich.domain.user.dto.response.UserHomeResponse;
@@ -39,140 +27,12 @@ import lombok.RequiredArgsConstructor;
 public class UserService {
 
     private final UserRepository userRepository;
-    private final OwnerRepository ownerRepository;
-    private final StoreRepository storeRepository;
     private final PointTransactionRepository pointTransactionRepository;
     private final JwtManager jwtManager;
 
-    @Value("${spring.jwt.access.expiration}")
-    private long accessTokenExpiration;
-
-    @Value("${spring.jwt.refresh.expiration}")
-    private long refreshTokenExpiration;
-
-    public KakaoApiResponseDTO getUserInfo(String accessToken) {
-        String userInfoUrl = "https://kapi.kakao.com/v2/user/me";
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization", "Bearer " + accessToken);
-        HttpEntity<Void> request = new HttpEntity<>(headers);
-
-        RestTemplate restTemplate = new RestTemplate();
-        ResponseEntity<KakaoApiResponseDTO> response = restTemplate.exchange(userInfoUrl, HttpMethod.GET, request,
-            KakaoApiResponseDTO.class);
-
-        return response.getBody();
-    }
-
     public User getUserInfos(String accessToken) {
-
         return userRepository.findByProviderId(accessToken)
             .orElseThrow(() -> new DefaultNullPointerException(ErrorCode.INVALID_AUTHENTICATION));
-    }
-
-    @Transactional
-    public TokenResponseDTO joinUser(String kakaoaccessToken) {
-        KakaoApiResponseDTO userInfo = getUserInfo(kakaoaccessToken);
-        User user = userRepository.findByProviderId("kakao_" + userInfo.getId()).orElse(null);
-
-        Boolean alreadyExists = false;
-        if (user == null) {
-            user = userRepository.save(User.create("kakao_" + userInfo.getId(), userInfo.getProperties().getNickname(),
-                userInfo.getKakaoAccount().getEmail(), userInfo.getProperties().getProfileImage(), "ROLE_USER"));
-        } else {
-            alreadyExists = true;
-        }
-
-        String accessToken = jwtManager.createAccessToken(user.getProviderId(), user.getRole());
-        String refreshToken = jwtManager.createRefreshToken();
-
-        user.updateRefreshToken(refreshToken);
-        userRepository.save(user);
-
-        return TokenResponseDTO.builder()
-            .alreadyExists(alreadyExists)
-            .accessToken(accessToken)
-            .refreshToken(refreshToken)
-            .accessTokenExpires(accessTokenExpiration)
-            .refreshTokenExpires(refreshTokenExpiration)
-            .build();
-    }
-
-    @Transactional
-    public TokenResponseDTO joinOwner(String kakaoAccessToken) {
-        KakaoApiResponseDTO userInfo = getUserInfo(kakaoAccessToken);
-
-        User user = userRepository.findByProviderId("kakao_" + userInfo.getId()).orElse(null);
-
-        Boolean alreadyExists = false;
-        if (user == null) {
-            user = userRepository.save(User.create("kakao_" + userInfo.getId(), userInfo.getProperties().getNickname(),
-                userInfo.getKakaoAccount().getEmail(), userInfo.getProperties().getProfileImage(), "ROLE_OWNER"));
-            Owner newOwner = ownerRepository.save(Owner.create(user));
-            storeRepository.save(Store.create(newOwner));
-        } else {
-            alreadyExists = true;
-        }
-
-        String accessToken = jwtManager.createAccessToken(user.getProviderId(), user.getRole());
-        String refreshToken = jwtManager.createRefreshToken();
-
-        user.updateRefreshToken(refreshToken);
-        userRepository.save(user);
-
-        return TokenResponseDTO.builder()
-            .alreadyExists(alreadyExists)
-            .accessToken(accessToken)
-            .refreshToken(refreshToken)
-            .accessTokenExpires(accessTokenExpiration)
-            .refreshTokenExpires(refreshTokenExpiration)
-            .build();
-    }
-
-    @Transactional
-    public TokenResponseDTO login(String accessToken) {
-        KakaoApiResponseDTO userInfo = getUserInfo(accessToken);
-
-        User user = userRepository.findByProviderId("kakao_" + userInfo.getId())
-            .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
-
-        String newAccessToken = jwtManager.createAccessToken(user.getProviderId(), user.getRole());
-        String newRefreshToken = jwtManager.createRefreshToken();
-
-        user.updateRefreshToken(newRefreshToken);
-        userRepository.save(user);
-
-        return TokenResponseDTO.builder()
-            .accessToken(newAccessToken)
-            .refreshToken(newRefreshToken)
-            .accessTokenExpires(accessTokenExpiration)
-            .refreshTokenExpires(refreshTokenExpiration)
-            .build();
-    }
-
-    @Transactional
-    public String reissueAccessToken(String refreshToken) {
-        User user = userRepository.findByRefreshToken(refreshToken)
-            .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 Refresh Token입니다."));
-
-        if (!jwtManager.isTokenExpired(refreshToken)) {
-            throw new IllegalArgumentException("Refresh Token이 만료되었습니다.");
-        }
-
-        return jwtManager.createAccessToken(user.getProviderId(), user.getRole());
-    }
-
-    @Transactional
-    public void additionalInfo(String userId, AdditionalInfoCreateDTO additionalInfoCreateDTO) {
-        User user = userRepository.findByProviderId(userId)
-            .orElseThrow(() -> new DefaultNullPointerException(ErrorCode.INVALID_AUTHENTICATION));
-
-		user.additionalInfo(
-			additionalInfoCreateDTO.getName(),
-			additionalInfoCreateDTO.getPhoneNum(),
-			additionalInfoCreateDTO.getAgreeAdvertisement(),
-			additionalInfoCreateDTO.getAgreeMarketing()
-		);
     }
 
     public WalletResponse getMyWallet(String userId) {
@@ -202,5 +62,30 @@ public class UserService {
             .orElseThrow(() -> new DefaultNullPointerException(ErrorCode.INVALID_AUTHENTICATION));
 
         return userRepository.findUserHomeData(user.getUserId());
+    }
+
+    @Transactional
+    public String reissueAccessToken(String refreshToken) {
+        User user = userRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 Refresh Token입니다."));
+
+        if (!jwtManager.isTokenExpired(refreshToken)) {
+            throw new IllegalArgumentException("Refresh Token이 만료되었습니다.");
+        }
+
+        return jwtManager.createAccessToken(user.getProviderId(), user.getRole());
+    }
+
+    @Transactional
+    public void additionalInfo(String userId, AdditionalInfoCreateDTO additionalInfoCreateDTO) {
+        User user = userRepository.findByProviderId(userId)
+                .orElseThrow(() -> new DefaultNullPointerException(ErrorCode.INVALID_AUTHENTICATION));
+
+        user.additionalInfo(
+                additionalInfoCreateDTO.getName(),
+                additionalInfoCreateDTO.getPhoneNum(),
+                additionalInfoCreateDTO.getAgreeAdvertisement(),
+                additionalInfoCreateDTO.getAgreeMarketing()
+        );
     }
 }

--- a/src/main/java/com/jangburich/domain/user/service/impl/KakaoLoginService.java
+++ b/src/main/java/com/jangburich/domain/user/service/impl/KakaoLoginService.java
@@ -1,0 +1,149 @@
+package com.jangburich.domain.user.service.impl;
+
+import com.jangburich.domain.owner.domain.Owner;
+import com.jangburich.domain.owner.domain.repository.OwnerRepository;
+import com.jangburich.domain.store.domain.Store;
+import com.jangburich.domain.store.repository.StoreRepository;
+import com.jangburich.domain.user.domain.*;
+import com.jangburich.domain.user.repository.UserRepository;
+import com.jangburich.domain.user.service.SocialLoginService;
+import com.jangburich.utils.JwtManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@Profile("!local")
+@RequiredArgsConstructor
+public class KakaoLoginService implements SocialLoginService {
+
+    private final JwtManager jwtManager;
+
+    private final OwnerRepository ownerRepository;
+    private final StoreRepository storeRepository;
+    private final UserRepository userRepository;
+
+    @Value("${spring.jwt.access.expiration}")
+    private long accessTokenExpiration;
+
+    @Value("${spring.jwt.refresh.expiration}")
+    private long refreshTokenExpiration;
+
+    @Override
+    public SocialLoginProvider getProvider(){
+        return SocialLoginProvider.KAKAO;
+    }
+
+    @Override
+    public SocialUserProfileDTO getUserInfo(String accessToken) {
+        String userInfoUrl = "https://kapi.kakao.com/v2/user/me";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<KakaoApiResponseDTO> response = restTemplate.exchange(userInfoUrl, HttpMethod.GET, request,
+                KakaoApiResponseDTO.class);
+
+        KakaoApiResponseDTO kakaoApiResponseDTO = response.getBody();
+
+        return SocialUserProfileDTO.builder()
+                .socialId(String.valueOf(kakaoApiResponseDTO.getId()))
+                .email(kakaoApiResponseDTO.getKakaoAccount().getEmail())
+                .name(kakaoApiResponseDTO.getKakaoAccount().getProfile().getNickname())
+                .profileImage(kakaoApiResponseDTO.getKakaoAccount().getProfile().getProfileImageUrl())
+                .provider(SocialLoginProvider.KAKAO)
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public TokenResponseDTO joinOwner(String kakaoAccessToken) {
+        SocialUserProfileDTO userInfo = getUserInfo(kakaoAccessToken);
+
+        User user = userRepository.findByProviderId("kakao_" + userInfo.getSocialId()).orElse(null);
+
+        Boolean alreadyExists = false;
+        if (user == null) {
+            user = userRepository.save(User.create("kakao_" + userInfo.getSocialId(), userInfo.getName(),
+                    userInfo.getEmail(), userInfo.getProfileImage(), "ROLE_OWNER"));
+            Owner newOwner = ownerRepository.save(Owner.create(user));
+            storeRepository.save(Store.create(newOwner));
+        } else {
+            alreadyExists = true;
+        }
+
+        String accessToken = jwtManager.createAccessToken(user.getProviderId(), user.getRole());
+        String refreshToken = jwtManager.createRefreshToken();
+
+        user.updateRefreshToken(refreshToken);
+        userRepository.save(user);
+
+        return TokenResponseDTO.builder()
+                .alreadyExists(alreadyExists)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .accessTokenExpires(accessTokenExpiration)
+                .refreshTokenExpires(refreshTokenExpiration)
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public TokenResponseDTO joinUser(String kakaoaccessToken) {
+        SocialUserProfileDTO userInfo = getUserInfo(kakaoaccessToken);
+        User user = userRepository.findByProviderId("kakao_" + userInfo.getSocialId()).orElse(null);
+
+        Boolean alreadyExists = false;
+        if (user == null) {
+            user = userRepository.save(User.create("kakao_" + userInfo.getSocialId(), userInfo.getName(),
+                    userInfo.getEmail(), userInfo.getProfileImage(), "ROLE_USER"));
+        } else {
+            alreadyExists = true;
+        }
+
+        String accessToken = jwtManager.createAccessToken(user.getProviderId(), user.getRole());
+        String refreshToken = jwtManager.createRefreshToken();
+
+        user.updateRefreshToken(refreshToken);
+        userRepository.save(user);
+
+        return TokenResponseDTO.builder()
+                .alreadyExists(alreadyExists)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .accessTokenExpires(accessTokenExpiration)
+                .refreshTokenExpires(refreshTokenExpiration)
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public TokenResponseDTO login(String accessToken) {
+        SocialUserProfileDTO userInfo = getUserInfo(accessToken);
+
+        User user = userRepository.findByProviderId("kakao_" + userInfo.getSocialId())
+                .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
+
+        String newAccessToken = jwtManager.createAccessToken(user.getProviderId(), user.getRole());
+        String newRefreshToken = jwtManager.createRefreshToken();
+
+        user.updateRefreshToken(newRefreshToken);
+        userRepository.save(user);
+
+        return TokenResponseDTO.builder()
+                .accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
+                .accessTokenExpires(accessTokenExpiration)
+                .refreshTokenExpires(refreshTokenExpiration)
+                .build();
+    }
+}

--- a/src/main/java/com/jangburich/domain/user/service/impl/MockLoginService.java
+++ b/src/main/java/com/jangburich/domain/user/service/impl/MockLoginService.java
@@ -1,0 +1,120 @@
+package com.jangburich.domain.user.service.impl;
+
+import com.jangburich.domain.owner.domain.Owner;
+import com.jangburich.domain.owner.domain.repository.OwnerRepository;
+import com.jangburich.domain.store.domain.Store;
+import com.jangburich.domain.store.repository.StoreRepository;
+import com.jangburich.domain.user.domain.SocialLoginProvider;
+import com.jangburich.domain.user.domain.SocialUserProfileDTO;
+import com.jangburich.domain.user.domain.TokenResponseDTO;
+import com.jangburich.domain.user.domain.User;
+import com.jangburich.domain.user.repository.UserRepository;
+import com.jangburich.domain.user.service.SocialLoginService;
+import com.jangburich.utils.JwtManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+import static com.jangburich.domain.user.domain.QUser.user;
+
+@Service
+@Profile("local")
+@RequiredArgsConstructor
+public class MockLoginService implements SocialLoginService {
+
+    private final JwtManager jwtManager;
+
+    private final OwnerRepository ownerRepository;
+    private final StoreRepository storeRepository;
+    private final UserRepository userRepository;
+
+    @Value("${spring.jwt.access.expiration}")
+    private long accessTokenExpiration;
+
+    @Value("${spring.jwt.refresh.expiration}")
+    private long refreshTokenExpiration;
+
+    @Override
+    public SocialLoginProvider getProvider(){
+        return SocialLoginProvider.LOCAL;
+    }
+
+    @Override
+    public SocialUserProfileDTO getUserInfo(String accessToken){
+        return SocialUserProfileDTO.builder()
+                .socialId(accessToken)
+                .email("fakeuser@test.com")
+                .name("Fake User")
+                .profileImage(null)
+                .provider(SocialLoginProvider.LOCAL)
+                .build();
+    }
+
+    @Override
+    public TokenResponseDTO joinOwner(String mockAccessToken){
+        SocialUserProfileDTO userInfo = getUserInfo(mockAccessToken);
+
+        User user = userRepository.save(User.create("local_" + userInfo.getSocialId(), userInfo.getName(),
+                userInfo.getEmail(), userInfo.getProfileImage(), "ROLE_OWNER"));
+        Owner newOwner = ownerRepository.save(Owner.create(user));
+        storeRepository.save(Store.create(newOwner));
+
+        String accessToken = jwtManager.createAccessToken(user.getProviderId(), user.getRole());
+        String refreshToken = jwtManager.createRefreshToken();
+
+        user.updateRefreshToken(refreshToken);
+
+        return TokenResponseDTO.builder()
+                .alreadyExists(false)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .accessTokenExpires(accessTokenExpiration)
+                .refreshTokenExpires(refreshTokenExpiration)
+                .build();
+    }
+
+    @Override
+    public TokenResponseDTO joinUser(String mockAccessToken){
+        SocialUserProfileDTO userInfo = getUserInfo(mockAccessToken);
+
+        User user = userRepository.save(User.create("local_" + userInfo.getSocialId(), userInfo.getName(),
+                userInfo.getEmail(), userInfo.getProfileImage(), "ROLE_USER"));
+
+        String accessToken = jwtManager.createAccessToken(user.getProviderId(), user.getRole());
+        String refreshToken = jwtManager.createRefreshToken();
+
+        user.updateRefreshToken(refreshToken);
+
+        return TokenResponseDTO.builder()
+                .alreadyExists(false)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .accessTokenExpires(accessTokenExpiration)
+                .refreshTokenExpires(refreshTokenExpiration)
+                .build();
+    }
+
+    @Override
+    public TokenResponseDTO login(String accessToken){
+        SocialUserProfileDTO userInfo = getUserInfo(accessToken);
+
+        User user = userRepository.findByProviderId(userInfo.getSocialId())
+                .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
+
+        String newAccessToken = jwtManager.createAccessToken(user.getProviderId(), user.getRole());
+        String newRefreshToken = jwtManager.createRefreshToken();
+
+        user.updateRefreshToken(newRefreshToken);
+        userRepository.save(user);
+
+        return TokenResponseDTO.builder()
+                .accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
+                .accessTokenExpires(accessTokenExpiration)
+                .refreshTokenExpires(refreshTokenExpiration)
+                .build();
+    }
+}

--- a/src/main/java/com/jangburich/global/error/ApiControllerAdvice.java
+++ b/src/main/java/com/jangburich/global/error/ApiControllerAdvice.java
@@ -1,5 +1,6 @@
 package com.jangburich.global.error;
 
+import com.jangburich.domain.user.controller.UserController;
 import com.jangburich.global.payload.ApiResponse;
 import com.jangburich.global.payload.ErrorCode;
 import com.jangburich.global.payload.ErrorResponse;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,0 @@
-server:
-  port: 8080
-
-spring:
-  application:
-    name: jangburich


### PR DESCRIPTION
# 📋 Pull Request

## 📌 관련 이슈
<!-- 관련 이슈를 연결해주세요. 예: #123, #456 -->
Closes #9

## 📝 변경 사항 요약
<!-- 이번 PR의 주요 변경 사항을 요약해주세요. -->

## 🔄 변경 유형
<!-- 해당하는 항목에 x 표시해주세요. (띄어쓰기 없이 [x]) -->
- [ ] 🐛 버그 수정 (Bug fix)
- [ ] ✨ 새 기능 (New feature)
- [X] ♻️ 리팩토링 (Refactoring)
- [ ] 🚀 성능 개선 (Performance improvement)
- [ ] 🧪 테스트 (Test)
- [ ] 📚 문서화 (Documentation)
- [ ] 🔧 설정 변경 (Configuration change)
- [ ] 기타 (설명: )

## 📸 스크린샷 / 데모
<!-- UI 변경사항이 있다면 스크린샷이나 GIF를 첨부해주세요. -->

## 🧪 테스트 방법
<!-- 이 PR을 테스트하는 방법을 단계별로 설명해주세요. -->
1. JoinOwner / JoinUser로 회원가입
2. 회원가입 후 로컬 db에 저장된 provider_id 값을 login api의 authrozation header에 넣고 로그인
3. 로그인 성공 시 발급된 accessToken 값을 Swagger Authroize에 추가

## ✅ 체크리스트
- [ ] 테스트 코드를 작성하였습니다.
- [ ] 모든 테스트가 통과합니다.
- [ ] 코딩 컨벤션을 준수하였습니다.
- [ ] 관련 문서를 업데이트하였습니다.
- [ ] 이슈에 명시된 요구사항을 모두 충족하였습니다.

## 👀 리뷰 포인트
<!-- 리뷰어가 특히 집중해서 봐야 할 부분이 있다면 작성해주세요. -->

## 📚 추가 정보
<!-- 추가 정보나 참고 사항을 작성해주세요. -->